### PR TITLE
fix(plugin): reject install when plugin name already exists

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -178,6 +178,14 @@ var pluginInstallCmd = &cobra.Command{
 			return fmt.Errorf("--npm, --brew, --repo, and --script are mutually exclusive")
 		}
 
+		manifest, err := plugin.LoadManifest()
+		if err != nil {
+			manifest = &plugin.Manifest{}
+		}
+		if err := ensureInstallNameAvailable(manifest, name); err != nil {
+			return err
+		}
+
 		inst, err := installer.FromPlugin(pluginInstall)
 		if err != nil {
 			return err
@@ -195,10 +203,6 @@ var pluginInstallCmd = &cobra.Command{
 			return fmt.Errorf("failed to install plugin %q: %w", name, err)
 		}
 
-		manifest, err := plugin.LoadManifest()
-		if err != nil {
-			manifest = &plugin.Manifest{}
-		}
 		manifest.Add(name, version, inst.PluginType(), inst.Source(), "")
 		if pluginInstall.Description != "" {
 			manifest.SetDescription(name, pluginInstall.Description)
@@ -484,4 +488,11 @@ func uniquePluginNames(args []string) []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+func ensureInstallNameAvailable(manifest *plugin.Manifest, name string) error {
+	if _, exists := manifest.Get(name); exists {
+		return fmt.Errorf("plugin %q already exists; use \"clime plugin update %s\" or uninstall it first", name, name)
+	}
+	return nil
 }

--- a/cmd/plugin_install_test.go
+++ b/cmd/plugin_install_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/git-hulk/clime/internal/plugin"
+)
+
+func TestEnsureInstallNameAvailable(t *testing.T) {
+	t.Parallel()
+
+	manifest := &plugin.Manifest{
+		Plugins: []plugin.ManifestEntry{
+			{Name: "account", Version: "1.0.0"},
+		},
+	}
+
+	err := ensureInstallNameAvailable(manifest, "account")
+	if err == nil {
+		t.Fatal("expected conflict error for existing plugin name")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error = %q, want conflict message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "clime plugin update account") {
+		t.Fatalf("error = %q, want update guidance", err.Error())
+	}
+}
+
+func TestEnsureInstallNameAvailableNoConflict(t *testing.T) {
+	t.Parallel()
+
+	manifest := &plugin.Manifest{
+		Plugins: []plugin.ManifestEntry{
+			{Name: "account", Version: "1.0.0"},
+		},
+	}
+
+	if err := ensureInstallNameAvailable(manifest, "opencli"); err != nil {
+		t.Fatalf("unexpected error for new plugin name: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a minimal name-conflict guard in `clime plugin install <name>`
- return an error when `<name>` already exists in managed plugins (manifest)
- include clear guidance to use update or uninstall first
- add focused tests for conflict and no-conflict cases

## Testing
- go test ./...

Closes #10
